### PR TITLE
Fix travertine api endpoint

### DIFF
--- a/server_versions.json
+++ b/server_versions.json
@@ -39,7 +39,7 @@
     "downloadLinks": [
       {
         "version": "latest",
-        "link": "https://papermc.io/api/v1/travertine/1.16/latest/download"
+        "link": "https://api.papermc.io/v2/projects/travertine/versions/1.16/builds/191/downloads/travertine-1.16-191.jar"
       }
     ]
   },


### PR DESCRIPTION
The old endpoint with API v1 downloads a 2KB JAR file that says the endpoint is deprecated.
This pull request addresses this issue.