### PR TITLE
fix: latest snapshot version

### DIFF
--- a/server_versions.json
+++ b/server_versions.json
@@ -464,7 +464,7 @@
     "type": "SERVER",
     "isPaperclip": false,
     "latestVersion": "1.21",
-    "latestSnapshot": "1.21",
+    "latestSnapshot": "1.21-rc1",
     "downloadLinks": [
       {
         "version": "1.21",


### PR DESCRIPTION
Changed latest snapshot version back to 1.21-rc1, because 1.21 isn't a snapshot version.